### PR TITLE
Fix exception handling from child process

### DIFF
--- a/lib/fork.rb
+++ b/lib/fork.rb
@@ -598,9 +598,8 @@ private
     raise NotRunning unless @pid
 
     if has_ctrl? && blocking
-      t = Thread.new { read_remaining_ctrl(false) }
+      read_remaining_ctrl(false)
       _, status = Process.wait2(@pid)
-      t.join
     else
       _, status = Process.wait2(@pid, blocking ? 0 : Process::WNOHANG)
     end

--- a/lib/fork.rb
+++ b/lib/fork.rb
@@ -597,11 +597,17 @@ private
   def _wait(blocking=true)
     raise NotRunning unless @pid
 
-    _, status = *Process.wait2(@pid, blocking ? 0 : Process::WNOHANG)
+    if has_ctrl? && blocking
+      t = Thread.new { read_remaining_ctrl(false) }
+      _, status = Process.wait2(@pid)
+      t.join
+    else
+      _, status = Process.wait2(@pid, blocking ? 0 : Process::WNOHANG)
+    end
     if status then
       @process_status = status
       @exit_status    = status.exitstatus
-      read_remaining_ctrl if has_ctrl?
+      read_remaining_ctrl if has_ctrl? && !blocking
     end
   rescue Errno::ECHILD # can happen if the process is already collected
     raise "Can't determine exit status of #{self}, make sure to not interfere with process handling externally" unless @process_status

--- a/test/unit/fork.rb
+++ b/test/unit/fork.rb
@@ -91,6 +91,14 @@ class ForkTest < Test::Unit::TestCase
     assert_equal value, result
   end
 
+  test 'Fork returns large value' do
+    fork = Fork.new :return do
+      'a' * 4100
+    end
+    fork.execute
+    assert_equal 'a' * 4100, fork.return_value
+  end
+
   test 'Fork#exception returns exception' do
     error = StandardError.new('abc')
     fork = Fork.new :exceptions do


### PR DESCRIPTION
If the child process raises an exception, this gets written to the ctrl pipe (when enabled with `:exceptions` option). Waiting for the child process to finish cannot complete until this ctrl pipe has been read.

Read from `ctrl` pipe in a new thread while waiting for child process in main thread.